### PR TITLE
Three updates

### DIFF
--- a/src/pages/bibliography.njk.html
+++ b/src/pages/bibliography.njk.html
@@ -3,45 +3,39 @@ layout: base
 templateEngineOverride: liquid
 title: Bibliography
 permalink: /bibliography/
-pagination:
-  data: collections.publications
-  reverse: true
-  alias: bibliography
-  size: 100
-  
 ---
 
 <h2>Publications</h2>
 
 <div class="projects">
-				
-				{%- for post in pagination.items -%}
+        {% assign publications = collections.publications | map: "data" | sort: 'year' | reverse %}
 
+				{%- for pub in publications -%}
 
-					{%bibtex%}@{{post.data.type}}{% raw %}{{% endraw %}{{post.data.pubkey}},
-						author = "{{post.data.author}}",
-						title = "{{post.data.title}}",
-						{%if post.data.booktitle %}
-						booktitle = "{{post.data.booktitle}}",
+					{%bibtex%}@{{pub.type}}{% raw %}{{% endraw %}{{pub.pubkey}},
+						author = "{{pub.author}}",
+						title = "{{pub.title}}",
+						{%if pub.booktitle %}
+						booktitle = "{{pub.booktitle}}",
 						{% endif %}
-						{%if post.data.editor %}
-						editor = "{{post.data.editor}}",
+						{%if pub.editor %}
+						editor = "{{pub.editor}}",
 						{% endif %}
-						{%if post.data.booktitle %}
-						pages = "{{post.data.pages}}",
+						{%if pub.booktitle %}
+						pages = "{{pub.pages}}",
 						{% endif %}
-						{%if post.data.journal %}
-						journal = "{{post.data.journal}}",
+						{%if pub.journal %}
+						journal = "{{pub.journal}}",
 						{% endif %}
-						{%if post.data.volume %}
-						volume = "{{post.data.volume}}",
+						{%if pub.volume %}
+						volume = "{{pub.volume}}",
 						{% endif %}
-						{% if post.data.url %}
-						url = "{{post.data.url}}",
+						{% if pub.url %}
+						url = "{{pub.url}}",
 						{% endif %}
-						year = "{{post.data.year}}"
+						year = "{{pub.year}}"
 						{% raw %}}{% endraw %}{%endbibtex%}
-					
+
 
 
 					{% endfor %}

--- a/src/pages/people.njk.md
+++ b/src/pages/people.njk.md
@@ -34,8 +34,9 @@ eleventyNavigation:
 
 {% if "Core Research" in person.labtitle %}
 <div class="labcore">
-<div class="labcore-pic"><img src="{{person.photo}}" alt="image of {{person.name}}" /></div>
-<div class="labcore-bio"><h4>{{person.name}}</h4><p>{{person.bio}} {{person.name}} can be reached at {{person.email}}.</p></div>
+<h4>{{person.name}}</h4>
+<img src="{{person.photo}}" alt="image of {{person.name}}" />
+<p>{{person.bio}} {{person.name}} can be reached at {{person.email}}.</p>
 </div>
 {% endif %}
 {% endif %}

--- a/src/pages/techne.njk.html
+++ b/src/pages/techne.njk.html
@@ -11,8 +11,6 @@ pagination:
   permalink: techne/{% if pagination.pageNumber > 0 %}page-{{ pagination.pageNumber }}/{% endif %}/
 ---
 
-{%- set comma = joiner(", ") -%}
-
 <h2>Techne</h2>
 
   {%- for post in techne -%}
@@ -20,12 +18,11 @@ pagination:
       <h3><a href="{{ post.url | url }}">{{ post.data.title }}</a></h3>
 
 <p><em>      {% for author in post.data.authors%}
+  {% set author_loop = loop %}
 {%- for person in LabPeople -%}
     {%- if author == person.key -%}
-{{- comma() -}}{{- person.name -}}
-{% endif %}
-{% endfor %}
-{% endfor %}; {{ post.date | postDate}}</em></p>
+{{- person.name -}}{{ ", " if not author_loop.last }}{% endif %}{% endfor %}{% endfor %};
+{{ post.date | postDate}}</em></p>
 
 
       {% if post.data.teaser %}

--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -72,11 +72,14 @@ div.csl-bib-body {
 div.labcore {
 	display:block;
 	margin-bottom: 10px;
-}
+  text-align: center;
 
-div.labcore-pic {
-	float:left;
-	width:400px;
-	margin-right:10px;
-overflow:auto;
+  h4, p {
+    text-align: left;
+  }
+
+  img {
+    max-width: 100%;
+    width: 400px;
+  }
 }


### PR DESCRIPTION
Three updates, for your perusal:

**[Recorganize "Core Research Team" layout](https://github.com/quinnanya/litlab.stanford.edu/commit/bdb20a68d2e8d450194e51765b4002588ef35f50)**
I've just reorganized the HTML here, and added a tiny bit of CSS.  A rule of modern CSS is not to use `float` for things like this (it's gone from being a ubiquitous technique to one which should be very rarely used these days).  A more involved layout that this should use `flexbox` instead.

**[Fix comma separation in /techne byline](https://github.com/quinnanya/litlab.stanford.edu/commit/9f11a8df294d7462dfa9a4cf09c9bd407122199b)**
You're not actually joining the authors here, you're just writing them out in a loop using the Liquid template syntax.  The solution is to write the comma after every author unless it's the last one, and Liquid provides the handy `loop.last` boolean to test that.  The catch here is that because of the double loop that resolves the person IDs into names, we need to know if we're on the last iteration of the parent loop.  The Liquid docs say `loop.parent.loop.last` should work, but it wouldn't for me, so I assigned the outer loop to a variable and used that instead.

**[Sort bibliography by year (desc.)](https://github.com/quinnanya/litlab.stanford.edu/commit/46a6037cbc62683f5272ac58d47c3bf3f2aee118)**
Here is one solution to this problem.  Since all the bibliography items are being displayed on the one page I removed the pagination.  As I write this it occurs to me that that probably wasn't smart.  Anyway, for now take a look at this solution.  I was confused at first as the file has a `.njk` extension (nunjucks templating syntax) and I didn't notice that the frontmatter has `templateEngineOverride: liquid` so I couldn't work out why the nunjucks syntax wasn't working...  Liquid (unlike nunjucks) doesn't seem to be able to sort on nested properties, so I had to use a map filter for this.

I'll come up with something you can use on pagination collections; tbh it will be easier just to write a dozen lines of javascript hitting the collections API in `.eleventy.js`, but I was trying to do this without just immediately resorting to the power-user toys...
