### PR TITLE
Sorting of (to be) paginated data

### DIFF
--- a/src/pages/bibliography.njk.html
+++ b/src/pages/bibliography.njk.html
@@ -1,39 +1,48 @@
----
-layout: base
-templateEngineOverride: liquid
-title: Bibliography
-permalink: /bibliography/
+---js
+{
+  layout: "base",
+  templateEngineOverride: "liquid",
+  title: "Bibliography",
+  permalink: "/bibliography/",
+  pagination: {
+    data: "collections.publications",
+    reverse: true,
+    alias: "publications",
+    size: 100,
+    before: function(paginationData, fullData) {
+      return paginationData.sort((a, b) => a.data.year - b.data.year);
+    }
+  }
+}
 ---
 
 <h2>Publications</h2>
 
 <div class="projects">
-        {% assign publications = collections.publications | map: "data" | sort: 'year' | reverse %}
-
 				{%- for pub in publications -%}
 
-					{%bibtex%}@{{pub.type}}{% raw %}{{% endraw %}{{pub.pubkey}},
-						author = "{{pub.author}}",
-						title = "{{pub.title}}",
-						{%if pub.booktitle %}
-						booktitle = "{{pub.booktitle}}",
+					{%bibtex%}@{{pub.data.type}}{% raw %}{{% endraw %}{{pub.data.pubkey}},
+						author = "{{pub.data.author}}",
+						title = "{{pub.data.title}}",
+						{%if pub.data.booktitle %}
+						booktitle = "{{pub.data.booktitle}}",
 						{% endif %}
-						{%if pub.editor %}
-						editor = "{{pub.editor}}",
+						{%if pub.data.editor %}
+						editor = "{{pub.data.editor}}",
 						{% endif %}
-						{%if pub.booktitle %}
-						pages = "{{pub.pages}}",
+						{%if pub.data.booktitle %}
+						pages = "{{pub.data.pages}}",
 						{% endif %}
-						{%if pub.journal %}
-						journal = "{{pub.journal}}",
+						{%if pub.data.journal %}
+						journal = "{{pub.data.journal}}",
 						{% endif %}
-						{%if pub.volume %}
-						volume = "{{pub.volume}}",
+						{%if pub.data.volume %}
+						volume = "{{pub.data.volume}}",
 						{% endif %}
-						{% if pub.url %}
-						url = "{{pub.url}}",
+						{% if pub.data.url %}
+						url = "{{pub.data.url}}",
 						{% endif %}
-						year = "{{pub.year}}"
+						year = "{{pub.data.year}}"
 						{% raw %}}{% endraw %}{%endbibtex%}
 
 


### PR DESCRIPTION
This PR returns the pagination to the `/bibliography/` page (so that it will paginate if/when there're > 100 items), and demonstrates a way to sort the data in that context that can be applied elsewhere.

A couple of things deserve mention:
1. To be able to use this solution the frontmatter for the template file has to be provided as a javascript object instead of YAML.
2. It's important that the data is sorted before pagination, so that pages are created in the right order -- this is why the liquid/nunjucks filters won't cut it here, and why we use the [`before` callback](https://www.11ty.dev/docs/pagination/#the-before-callback) to the 11ty pagination API.
3. The other (perhaps more obvious) way to do this would be to [create a collection using the configuration API](https://www.11ty.dev/docs/collections/#advanced-custom-filtering-and-sorting).  Both methods allow arbitrary javascript, and so are very powerful.  I think the way I've chosen to do it here is a little less heavy-handed and ties the logic to the template which makes it easier to reason about for future readers.