### PR TITLE
Updates 2023-03-26

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -122,6 +122,10 @@ eleventyConfig.addFilter("numericDate", (dateObj) => {
   eleventyConfig.addPairedShortcode("bibtex", require('eleventy-plugin-bibtex'));
   
 
+  eleventyConfig.addFilter("filterCollectionByProject", (collection, project) =>
+    collection.filter((item) => item.data.project == project)
+  );
+
   // Base Config
   return {
     dir: {

--- a/src/layouts/project.njk.html
+++ b/src/layouts/project.njk.html
@@ -80,6 +80,16 @@ layout: base
 	  {% endif %}
 	  {% endfor %}
 	  {% endfor %}
+
+    {% set publications = collections.publications | filterCollectionByProject(key) %}
+    {% if publications.length %}
+      <strong>Publications</strong>
+      <ul>
+        {% for publication in publications %}
+          <li>{{publication.data.title}}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
     </div>
   </div>
  

--- a/src/layouts/project.njk.html
+++ b/src/layouts/project.njk.html
@@ -40,9 +40,10 @@ layout: base
         
 		
 		
+  {% set member_loop = loop %}
 	{%- for person in LabPeople -%}
 	    {%- if member == person.key -%}
-	{{- person.name -}}{{ ", " if not author_loop.last }}{% endif %}{% endfor %}{% endfor %};
+	{{- person.name -}}{{ ", " if not member_loop.last }}{% endif %}{% endfor %}{% endfor %};
 	
         {% endif %}
       </p>
@@ -51,9 +52,10 @@ layout: base
       <p class="card-text"><strong>Collaborators: </strong>
         {%-for collaborator in collaborators-%}
 		
+    {% set collaborator_loop = loop %}
 		{%- for person in LabPeople -%}
 		    {%- if collaborator == person.key -%}
-		{{- person.name -}}{{ ", " if not author_loop.last }}{% endif %}{% endfor %}{% endfor %};
+		{{- person.name -}}{{ ", " if not collaborator_loop.last }}{% endif %}{% endfor %}{% endfor %};
 		
         {% endif %}
       </p>

--- a/src/pages/bibliography.njk.html
+++ b/src/pages/bibliography.njk.html
@@ -3,7 +3,7 @@
   layout: "base",
   templateEngineOverride: "liquid",
   title: "Bibliography",
-  permalink: "/bibliography/",
+  permalink: "bibliography/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber | plus: 1 }}/{% endif %}",
   eleventyNavigation: {
     key: "Bibliography",
     order: "8"

--- a/src/pages/news.njk.html
+++ b/src/pages/news.njk.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+permalink: "news/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber + 1 }}/{% endif %}"
 eleventyNavigation:
   key: News
   order: 3
@@ -8,7 +9,6 @@ pagination:
   size: 10
   alias: news
   reverse: true
-  permalink: news/{% if pagination.pageNumber > 0 %}page-{{ pagination.pageNumber }}/{% endif %}/
 ---
 <h2>News</h2>
 

--- a/src/pages/pamphlets.njk
+++ b/src/pages/pamphlets.njk
@@ -18,13 +18,15 @@
   }
 }
 ---
+<div class="jumplinks-container">
+<div>
 <h2>Pamphlets</h2>
 
 
                        {%- for post in pagination.items -%}
 					   {% if post.data.pamphlet %}
 					   
-					   <div class="pamphlet">
+					   <div class="pamphlet" id="{{post.data.pubkey}}">
 					   <h4><a href="{{post.data.pamphlet.pdf}}">{{post.data.title}}</a></h4>
 					  
 					   <a href="{{post.data.pamphlet.pdf}}"><img src="{{post.data.pamphlet.image}}" alt="pamphlet cover for {{post.data.title}}"  /></a>
@@ -48,3 +50,15 @@
 					   {% endif %}
 					   {% endfor %}
 					   
+</div>
+
+<aside class="jumplinks card">
+<ul>
+{%- for post in pagination.items -%}
+  {% if post.data.pamphlet %}
+    <li><a href="#{{post.data.pubkey}}">{{post.data.title}}</a></li>
+  {% endif %}
+{% endfor %}
+</ul>
+</aside>
+</div>

--- a/src/pages/pamphlets.njk
+++ b/src/pages/pamphlets.njk
@@ -2,7 +2,7 @@
 {
   layout: "base",
   title: "Pamphlets",
-  permalink: "/pamphlets/",
+  permalink: "pamphlets/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber + 1 }}/{% endif %}",
   eleventyNavigation: {
     key: "Pamphlets",
     order: "6"

--- a/src/pages/project-archive.njk.html
+++ b/src/pages/project-archive.njk.html
@@ -14,7 +14,8 @@
   }
 }
 ---
-
+<div class="jumplinks-container">
+<div>
 <h2>Project Archive</h2>
 
 <p>See also our <a href="/projects">current projects<a>.</p>
@@ -29,7 +30,7 @@
 					   {% if post.data.status %}
 					   {% if 'archive' == post.data.status %}
 					   
-				       <div class="card__item cf">
+				       <div class="card__item cf" id="{{ post.data.key }}">
 				           <div class="card__image">
 				               <a href="{{post.data.permalink}}">
 				                   <div class="image">
@@ -55,4 +56,17 @@
        </section>
   </div>
 
+</div>
+
+</div>
+
+<aside class="jumplinks card">
+  <ul>
+    {%- for post in pagination.items -%}
+    {% if post.data.status and (post.data.status === "archive") %}
+    <li><a href="#{{post.data.key}}">{{post.data.title}}</a></li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</aside>
 </div>

--- a/src/pages/project-archive.njk.html
+++ b/src/pages/project-archive.njk.html
@@ -2,7 +2,7 @@
 {
   layout: "base",
   title: "Project Archive",
-  permalink: "projects/archive/",
+  permalink: "projects/archive/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber + 1 }}/{% endif %}",
   pagination: {
     data: "collections.projects",
     reverse: true,

--- a/src/pages/projects.njk.html
+++ b/src/pages/projects.njk.html
@@ -2,7 +2,7 @@
 {
   layout: "base",
   title: "Projects",
-  permalink: "/projects/",
+  permalink: "projects/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber + 1}}/{% endif %}",
   eleventyNavigation: {
     key: "Projects",
     order: "5"

--- a/src/pages/projects.njk.html
+++ b/src/pages/projects.njk.html
@@ -19,6 +19,8 @@
 }
 ---
 
+<div class="jumplinks-container">
+<div>
 <h2>Projects</h2>
 
 <p>See past projects in the <a href="/projects/archive/">project archive<a>.</p>
@@ -33,7 +35,7 @@
 					   {% if post.data.status %}
 					   {% if 'archive' !== post.data.status %}
 					   
-				       <div class="card__item cf">
+				       <div class="card__item cf" id="{{ post.data.key }}">
 				           <div class="card__image">
 				               <a href="{{post.data.permalink}}">
 				                   <div class="image">
@@ -58,4 +60,17 @@
            </div>
        </section>
   </div>
+</div>
+
+</div>
+
+<aside class="jumplinks card">
+  <ul>
+    {%- for post in pagination.items -%}
+    {% if post.data.status and (post.data.status !== "archive") %}
+    <li><a href="#{{post.data.key}}">{{post.data.title}}</a></li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</aside>
 </div>

--- a/src/pages/techne.njk.html
+++ b/src/pages/techne.njk.html
@@ -1,5 +1,6 @@
 ---
 layout: base
+permalink: "techne/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber + 1 }}/{% endif %}"
 eleventyNavigation:
   key: Techne
   order: 7
@@ -8,7 +9,6 @@ pagination:
   size: 10
   alias: techne
   reverse: true
-  permalink: techne/{% if pagination.pageNumber > 0 %}page-{{ pagination.pageNumber }}/{% endif %}/
 ---
 
 <h2>Techne</h2>

--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -136,6 +136,8 @@ div.pamphlet {
 	margin-bottom: 10px;
   text-align: center;
   max-width:800px;
+  scroll-margin-top: 2em;
+  margin-top: 2em;
 
   h4, p {
     text-align: left;

--- a/src/scss/_jumplinks.scss
+++ b/src/scss/_jumplinks.scss
@@ -1,0 +1,36 @@
+.jumplinks-container {
+  align-items: flex-start;
+  display: flex;
+  transform: scale(1);
+
+  :target {
+    border-radius: 0.375rem; // to match .card
+    outline: 1px solid rgba(157, 28, 50, 0.5);
+    outline-offset: 4px;
+    scroll-margin-top: 2em;
+  }
+}
+
+.jumplinks {
+  flex: 0 0 auto;
+  margin: 2em 1em 2em 2em;
+  max-height: calc(100vh - 4em);
+  overflow-y: scroll;
+  padding: 2em 1em 1em 0;
+  position: sticky;
+  right: 0;
+  top: 2em;
+  width: 400px;
+
+  li {
+    margin-bottom: 0.5em;
+    padding-left: 1em;
+    text-indent: -1em;
+  }
+}
+
+@media (max-width: 992px) {
+  .jumplinks {
+    display: none;
+  }
+}

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -64,6 +64,7 @@
 @import "grid";
 @import "card";
 @import "pagination";
+@import "jumplinks";
 
 /*body {
   color: red !important;


### PR DESCRIPTION
Here's some commits to address some of these needs, offered for your consideration.  Hopefully you can adapt or change things if they're not exactly as you want them, but let me know if there's anything amiss.  More later.

> Paths:
> - Could news just be /news and techne just be /techne, and then the sub-pages with a number appended on the end (/news/1, etc.)? Right now they're getting the .njk added to the path, and I'm not sure why. (We also have an annoying /litlab-website path prefix right now, but we're planning on removing that when we launch)

Well I confess it took me a few minutes to work out what was going on here and how to get this right, but I've fixed up the `/news/` and `/techne/` routes, and improved the pagination routing too.  Once I'd worked out why it was broken for those two but not for other pages, I realized that the `/bibliography/`, `/pamphlets/`, `/projects/`, and `projects/archives/` routes were all misconfigured too -- they were building correctly only in virtue of having just a single page (having less than the 100 items set as the pagination page size) -- so I've fixed those too.  Part of the confusion and awkwardness here is that I've had to make functionally the same change in (literally) *four* different combinations of syntaxes to get everything working... (see 8b7a2dccea8fbc304b93a8e8f1898fbf0b635b86)

> Pamphlets and Project Archive:
> - Is it possible to add a "table of contents" on the right side of each page, with just a text list of jump anchor links for each pamphlet (or project) listed on the page? With the projects it makes more of a difference as the project list gets longer.

Okay, I've implemented something in 1ae89431.  I've kept it as simple as possible, but it's necessarily a little involved.
Some notes:
- I've implemented the sidebar on both the Projects and the Projects Archive pages -- I hope that was what you wanted!
- As mentioned above, these pages are set to do pagination, but with 100 items per page, which none of them reach yet.  The sidebar menu will present jumplinks for the items on the current page, so if/when these collections grow to > 100 items the sidebar will adjust accordingly.  Something to bear in mind.
- I've fixed the width of the sidebar at 400px; this means that the projects on the Projects pages get a little more squeezed.
- On smaller screens the sidebar just disappears, as there's not room for it.
- There are a bunch of little css tricks in there to keep the sidebar from getting stuck or getting lost or overflowing the page etc.  There's also a little (reasonably subtle?) indication of currently targeted item (which helps especially with the projects that are two-abreast).

> Project pages:
> - Collaborators and Members have the weird trailing comma despite my best efforts to get rid of them. 😥

Fixed in 8ef033ac.

> - Would it be possible to turn my hackish "float" for the box into something modern?

Yes and no.  The way you have it working right now is a genuine and legitimate use of float -- if the box is short, longer text will flow around it.  If that's they way you want it, then you need a float.  Replacing the float with flexbox or grid will create a different layout.  Depends what you want, really.

> - What's the way to check if any results exist so that "Publications" only shows up if there's publications?

Example in c3428c80; should be easy to extend/alter depending on what information you want there.

> Menu:
> - Is it possible to do a dropdown menu, so that the top-level items with things nested underneath just trigger the drop-down, and aren't linkable?

Yes, but it will require rewriting the entire nav (what to do with the hamburger menu on mobile, for example?).  I'll take a look later, but I wanted to PR these changes now before I lose my concentration :)
